### PR TITLE
refactor: use JdbcTemplate in CORS origin DAO

### DIFF
--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/constant/SQLQueries.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/constant/SQLQueries.java
@@ -29,49 +29,49 @@ public class SQLQueries {
     public static final String GET_CORS_ORIGINS_BY_TENANT_ID =
             "SELECT ID, ORIGIN, UUID " +
             "FROM IDN_CORS_ORIGIN " +
-            "WHERE TENANT_ID = :TENANT_ID; " +
+            "WHERE TENANT_ID = ? " +
             "ORDER BY ID ASC";
 
     public static final String GET_CORS_ORIGINS_BY_APPLICATION_ID =
             "SELECT ID, ORIGIN, UUID " +
             "FROM IDN_CORS_ORIGIN " +
             "INNER JOIN IDN_CORS_ASSOCIATION ON IDN_CORS_ORIGIN.ID = IDN_CORS_ASSOCIATION.IDN_CORS_ORIGIN_ID " +
-            "WHERE IDN_CORS_ORIGIN.TENANT_ID = :TENANT_ID; AND IDN_CORS_ASSOCIATION.SP_APP_ID = :SP_APP_ID; " +
+            "WHERE IDN_CORS_ORIGIN.TENANT_ID = ? AND IDN_CORS_ASSOCIATION.SP_APP_ID = ? " +
             "ORDER BY ID ASC";
 
     public static final String GET_CORS_ORIGIN_ID =
             "SELECT ID FROM IDN_CORS_ORIGIN " +
-            "WHERE TENANT_ID = :TENANT_ID; AND ORIGIN = :ORIGIN;";
+            "WHERE TENANT_ID = ? AND ORIGIN = ?";
 
     public static final String GET_CORS_ORIGIN_ID_BY_UUID =
             "SELECT ID " +
             "FROM IDN_CORS_ORIGIN " +
-            "WHERE UUID = :UUID;";
+            "WHERE UUID = ?";
 
     public static final String INSERT_CORS_ORIGIN =
             "INSERT INTO IDN_CORS_ORIGIN (TENANT_ID, ORIGIN, UUID) " +
-            "VALUES (:TENANT_ID;, :ORIGIN;, :UUID;)";
+            "VALUES (?, ?, ?)";
 
     public static final String INSERT_CORS_ASSOCIATION =
             "INSERT INTO IDN_CORS_ASSOCIATION (IDN_CORS_ORIGIN_ID, SP_APP_ID) " +
-            "VALUES (?,?)";
+            "VALUES (?, ?)";
 
     public static final String DELETE_ORIGIN =
             "DELETE " +
             "FROM IDN_CORS_ORIGIN " +
-            "WHERE ID = :ID;";
+            "WHERE ID = ?";
 
     public static final String GET_CORS_APPLICATION_IDS_BY_CORS_ORIGIN_ID =
             "SELECT SP_APP_ID " +
             "FROM IDN_CORS_ASSOCIATION " +
-            "WHERE IDN_CORS_ORIGIN_ID = :IDN_CORS_ORIGIN_ID;";
+            "WHERE IDN_CORS_ORIGIN_ID = ?";
 
     public static final String GET_CORS_APPLICATIONS_BY_CORS_ORIGIN_ID =
             "SELECT SP_APP.UUID, SP_APP.APP_NAME " +
             "FROM SP_APP " +
             "INNER JOIN IDN_CORS_ASSOCIATION ON IDN_CORS_ASSOCIATION.SP_APP_ID = SP_APP.ID " +
             "INNER JOIN IDN_CORS_ORIGIN ON IDN_CORS_ASSOCIATION.IDN_CORS_ORIGIN_ID = IDN_CORS_ORIGIN.ID " +
-            "WHERE IDN_CORS_ORIGIN.UUID = :UUID;";
+            "WHERE IDN_CORS_ORIGIN.UUID = ?";
 
     public static final String DELETE_CORS_APPLICATION_ASSOCIATION =
             "DELETE " +

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/dao/impl/CORSOriginDAOImpl.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/dao/impl/CORSOriginDAOImpl.java
@@ -49,7 +49,6 @@ import static org.wso2.carbon.identity.cors.mgt.core.constant.SQLQueries.INSERT_
 import static org.wso2.carbon.identity.cors.mgt.core.constant.SchemaConstants.CORSOriginTableColumns;
 import static org.wso2.carbon.identity.cors.mgt.core.constant.SchemaConstants.CORSOriginTableColumns.ID;
 import static org.wso2.carbon.identity.cors.mgt.core.constant.SchemaConstants.CORSOriginTableColumns.ORIGIN;
-import static org.wso2.carbon.identity.cors.mgt.core.constant.SchemaConstants.CORSOriginTableColumns.TENANT_ID;
 import static org.wso2.carbon.identity.cors.mgt.core.constant.SchemaConstants.CORSOriginTableColumns.UNIQUE_ID;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.util.ErrorUtils.handleServerException;
 
@@ -159,10 +158,15 @@ public class CORSOriginDAOImpl implements CORSOriginDAO {
                             });
                 }
 
-                // cleanupDanglingOrigins(template, tenantId); // Disabled temporarily.
+                // Cleanup dangling origins (origins without any association to an application) is disabled temporary.
+                // Even the CORS Origins are stored for each application separately, the CORS valve filters them
+                // based on the tenant level. Because of that there might be other applications which are not configured
+                // allowed origins but still working as another application has already set is as an allowed origin.
+                // Related issue: https://github.com/wso2/product-is/issues/11241
+                // cleanupDanglingOrigins(template, tenantId);
                 return null;
             });
-        } catch (TransactionException | DataAccessException e) {
+        } catch (TransactionException e) {
             throw handleServerException(ERROR_CODE_CORS_ADD, e, tenantDomain);
         }
     }
@@ -209,7 +213,7 @@ public class CORSOriginDAOImpl implements CORSOriginDAO {
                 }
                 return null;
             });
-        } catch (TransactionException | DataAccessException e) {
+        } catch (TransactionException e) {
             throw handleServerException(ERROR_CODE_CORS_ADD, e, tenantDomain);
         }
     }
@@ -238,12 +242,15 @@ public class CORSOriginDAOImpl implements CORSOriginDAO {
                             });
                 }
 
-                // cleanupDanglingOrigins(template, tenantId); // Disabled temporarily.
+                // Cleanup dangling origins (origins without any association to an application) is disabled temporary.
+                // Even the CORS Origins are stored for each application separately, the CORS valve filters them
+                // based on the tenant level. Because of that there might be other applications which are not configured
+                // allowed origins but still working as another application has already set is as an allowed origin.
+                // Related issue: https://github.com/wso2/product-is/issues/11241
+                // cleanupDanglingOrigins(template, tenantId);
                 return null;
             });
-        } catch (CORSManagementServiceServerException e) {
-            throw e;
-        } catch (TransactionException | DataAccessException e) {
+        } catch (TransactionException e) {
             throw handleServerException(ERROR_CODE_CORS_DELETE, e, currentId[0]);
         }
     }


### PR DESCRIPTION
## Summary
- refactor CORS origin DAO to use JdbcTemplate with transactions
- switch CORS SQL queries to positional parameters for JdbcTemplate compatibility

## Testing
- `mvn -q -pl components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c025eb8588833092e0bfa9ee77f8f8